### PR TITLE
IAM Path and GovCloud/Partition Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ module "cloudtrail-logging" {
 |------|-------------|:----:|:-----:|:-----:|
 | cloudtrail\_bucket | Name of bucket for CloudTrail logs | string | n/a | yes |
 | cloudtrail\_name | Name for the CloudTrail | string | `"cloudtrail-all"` | no |
+| iam\_path | Path for the iam role | string | `/` | no |
 | kms\_key\_id | KMS key ARN to use for encrypting CloudTrail logs | string | n/a | yes |
 | log\_group\_name | Name for CloudTrail log group | string | `"cloudtrail2cwl"` | no |
 | region | Region that CloudWatch logging and the S3 bucket will live in | string | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,12 @@
 data "aws_caller_identity" "current" {
 }
 
+data "aws_partition" "current" {
+}
+
 locals {
   account_id = data.aws_caller_identity.current.account_id
+  partition  = data.aws_partition.current.partition
 }
 
 resource "aws_cloudtrail" "trail" {
@@ -18,6 +22,7 @@ resource "aws_cloudtrail" "trail" {
 
 resource "aws_iam_role" "cloudtrail_cloudwatch_events_role" {
   name_prefix        = "cloudtrail_events_role"
+  path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.cwl_assume_policy.json
 }
 
@@ -45,7 +50,7 @@ data "aws_iam_policy_document" "cwl_policy" {
     actions = ["logs:CreateLogStream"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${local.account_id}:log-group:${aws_cloudwatch_log_group.cwl_loggroup.name}:log-stream:*",
+      "arn:${local.partition}:logs:${var.region}:${local.account_id}:log-group:${aws_cloudwatch_log_group.cwl_loggroup.name}:log-stream:*",
     ]
   }
 
@@ -54,7 +59,7 @@ data "aws_iam_policy_document" "cwl_policy" {
     actions = ["logs:PutLogEvents"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${local.account_id}:log-group:${aws_cloudwatch_log_group.cwl_loggroup.name}:log-stream:*",
+      "arn:${local.partition}:logs:${var.region}:${local.account_id}:log-group:${aws_cloudwatch_log_group.cwl_loggroup.name}:log-stream:*",
     ]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,12 @@ variable "cloudtrail_name" {
   type        = string
 }
 
+variable "iam_path" {
+  default     = "/"
+  description = "Path under which to put the IAM role. Should begin and end with a '/'."
+  type        = string
+}
+
 variable "kms_key_id" {
   description = "KMS key ARN to use for encrypting CloudTrail logs"
   type        = string


### PR DESCRIPTION
Thanks for the modules.

I made two minor improvements to this module, but they do not break backward compatibility.

* I added an input variable `iam_path` that allows the user to specify a path for the create IAM role. This allows the module to work with IAM policies that put some restrictions on the passrole capability.
* I grab the current partition (`aws`, `aws-us-gov`, should work for China, too) and use that to create the ARNs.