### PR TITLE
Adds ability to enable s3 and lambda event selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ module "cloudtrail-logging" {
 |------|-------------|:----:|:-----:|:-----:|
 | cloudtrail\_bucket | Name of bucket for CloudTrail logs | string | n/a | yes |
 | cloudtrail\_name | Name for the CloudTrail | string | `"cloudtrail-all"` | no |
+| iam\_path | Path for the iam role | string | `/` | no |
 | kms\_key\_id | KMS key ARN to use for encrypting CloudTrail logs | string | n/a | yes |
 | log\_group\_name | Name for CloudTrail log group | string | `"cloudtrail2cwl"` | no |
 | region | Region that CloudWatch logging and the S3 bucket will live in | string | n/a | yes |

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,10 @@ data "aws_partition" "current" {
 locals {
   account_id = data.aws_caller_identity.current.account_id
   partition  = data.aws_partition.current.partition
+
+  # Need a list to work with for_each, but don't actually want to for_each
+  log_s3     = length(var.s3_object_level_buckets) > 0 ? [ true ] : [ ]
+  log_lambda = length(var.lambda_functions)        > 0 ? [ true ] : [ ]
 }
 
 resource "aws_cloudtrail" "trail" {
@@ -18,6 +22,28 @@ resource "aws_cloudtrail" "trail" {
   kms_key_id                 = var.kms_key_id
   name                       = var.cloudtrail_name
   s3_bucket_name             = var.cloudtrail_bucket
+
+  # S3 object logging:
+  event_selector{
+    read_write_type           = "All"
+    include_management_events = true
+
+    dynamic "data_resource" {
+      for_each = local.log_s3
+      content {
+        type   = "AWS::S3::Object"
+        values = var.s3_object_level_buckets
+      }
+    }
+
+    dynamic "data_resource" {
+      for_each = local.log_lambda
+      content {
+        type   = "AWS::Lambda::Function"
+        values = var.lambda_functions
+      }
+    }
+  }
 }
 
 resource "aws_iam_role" "cloudtrail_cloudwatch_events_role" {

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,12 @@
 data "aws_caller_identity" "current" {
 }
 
+data "aws_partition" "current" {
+}
+
 locals {
   account_id = data.aws_caller_identity.current.account_id
+  partition  = data.aws_partition.current.partition
 }
 
 resource "aws_cloudtrail" "trail" {
@@ -18,6 +22,7 @@ resource "aws_cloudtrail" "trail" {
 
 resource "aws_iam_role" "cloudtrail_cloudwatch_events_role" {
   name_prefix        = "cloudtrail_events_role"
+  path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.cwl_assume_policy.json
 }
 
@@ -45,7 +50,7 @@ data "aws_iam_policy_document" "cwl_policy" {
     actions = ["logs:CreateLogStream"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${local.account_id}:log-group:${aws_cloudwatch_log_group.cwl_loggroup.name}:log-stream:*",
+      "arn:${local.partition}:logs:${var.region}:${local.account_id}:log-group:${aws_cloudwatch_log_group.cwl_loggroup.name}:log-stream:*",
     ]
   }
 
@@ -54,7 +59,7 @@ data "aws_iam_policy_document" "cwl_policy" {
     actions = ["logs:PutLogEvents"]
 
     resources = [
-      "arn:aws:logs:${var.region}:${local.account_id}:log-group:${aws_cloudwatch_log_group.cwl_loggroup.name}:log-stream:*",
+      "arn:${local.partition}:logs:${var.region}:${local.account_id}:log-group:${aws_cloudwatch_log_group.cwl_loggroup.name}:log-stream:*",
     ]
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -20,6 +20,12 @@ variable "kms_key_id" {
   type        = string
 }
 
+variable "lambda_functions" {
+  default     = [ ]
+  description = "Lambda functions to log. Specify `[\"arn:aws:lambda\"]` for all, or `[ ]` for none."
+  type        = list
+}
+
 variable "log_group_name" {
   default     = "cloudtrail2cwl"
   description = "Name for CloudTrail log group"
@@ -35,4 +41,10 @@ variable "retention_in_days" {
   default     = 7
   description = "How long should CloudTrail logs be retained in CloudWatch (does not affect S3 storage). Set to -1 for indefinite storage."
   type        = number
+}
+
+variable "s3_object_level_buckets" {
+  default     = [ ]
+  description = "ARNs of buckets for which to enable object level logging. Specify `[\"arn:aws:s3:::\"]` for all, or `[ ]` for none. If listing ARNs, make sure to end each one with a `/`."
+  type        = list
 }

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,12 @@ variable "cloudtrail_name" {
   type        = string
 }
 
+variable "iam_path" {
+  default     = "/"
+  description = "Path under which to put the IAM role. Should begin and end with a '/'."
+  type        = string
+}
+
 variable "kms_key_id" {
   description = "KMS key ARN to use for encrypting CloudTrail logs"
   type        = string


### PR DESCRIPTION
Note: Requires (and includes the contents of) PR #4 , so review that first.

To enable all:
```
  s3_object_level_buckets = [ "arn:${var.aws_partition}:s3:::"  ]
  lambda_functions        = [ "arn:${var.aws_partition}:lambda" ]
```

To enable specific buckets, specify the arns of those buckets.
