### PR TITLE
Allow to assign tags to the cloudtrail resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,15 +20,17 @@ module "cloudtrail-logging" {
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| cloudtrail\_bucket | Name of bucket for CloudTrail logs | string | n/a | yes |
-| cloudtrail\_name | Name for the CloudTrail | string | `"cloudtrail-all"` | no |
-| iam\_path | Path for the iam role | string | `/` | no |
-| kms\_key\_id | KMS key ARN to use for encrypting CloudTrail logs | string | n/a | yes |
-| log\_group\_name | Name for CloudTrail log group | string | `"cloudtrail2cwl"` | no |
-| region | Region that CloudWatch logging and the S3 bucket will live in | string | n/a | yes |
-| retention\_in\_days | How long should CloudTrail logs be retained in CloudWatch \(does not affect S3 storage\). Set to -1 for indefinite storage. | number | `"7"` | no |
+| Name                | Description                                                                                                                 |    Type     |      Default       | Required |
+|---------------------|-----------------------------------------------------------------------------------------------------------------------------|:-----------:|:------------------:|:--------:|
+| cloudtrail\_bucket  | Name of bucket for CloudTrail logs                                                                                          |   string    |        n/a         |   yes    |
+| cloudtrail\_name    | Name for the CloudTrail                                                                                                     |   string    | `"cloudtrail-all"` |    no    |
+| iam\_path           | Path for the iam role                                                                                                       |   string    |        `/`         |    no    |
+| kms\_key\_id        | KMS key ARN to use for encrypting CloudTrail logs                                                                           |   string    |        n/a         |   yes    |
+| log\_group\_name    | Name for CloudTrail log group                                                                                               |   string    | `"cloudtrail2cwl"` |    no    |
+| region              | Region that CloudWatch logging and the S3 bucket will live in                                                               |   string    |        n/a         |   yes    |
+| retention\_in\_days | How long should CloudTrail logs be retained in CloudWatch \(does not affect S3 storage\). Set to -1 for indefinite storage. |   number    |       `"7"`        |    no    |
+| tags                | Mapping of any extra tags you want added to resources                                                                       | map(string) |        `{}`          |    no    |
+
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -18,12 +18,14 @@ resource "aws_cloudtrail" "trail" {
   kms_key_id                 = var.kms_key_id
   name                       = var.cloudtrail_name
   s3_bucket_name             = var.cloudtrail_bucket
+  tags                       = var.tags
 }
 
 resource "aws_iam_role" "cloudtrail_cloudwatch_events_role" {
   name_prefix        = "cloudtrail_events_role"
   path               = var.iam_path
   assume_role_policy = data.aws_iam_policy_document.cwl_assume_policy.json
+  tags               = var.tags
 }
 
 resource "aws_iam_role_policy" "cwl_policy" {
@@ -68,9 +70,11 @@ resource "aws_cloudwatch_log_group" "cwl_loggroup" {
   name              = var.log_group_name
   kms_key_id        = var.kms_key_id
   retention_in_days = var.retention_in_days == -1 ? null : var.retention_in_days
+  tags              = var.tags
 }
 
 resource "aws_cloudwatch_log_stream" "cwl_stream" {
   name           = local.account_id
   log_group_name = aws_cloudwatch_log_group.cwl_loggroup.name
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -36,3 +36,9 @@ variable "retention_in_days" {
   description = "How long should CloudTrail logs be retained in CloudWatch (does not affect S3 storage). Set to -1 for indefinite storage."
   type        = number
 }
+
+variable "tags" {
+  default     = {}
+  description = "Mapping of any extra tags you want added to resources"
+  type        = map(string)
+}


### PR DESCRIPTION
Currently resources created by module do not accept tags. 

This PR adds the capability to allow to assign tags to Cloudtrail related resources.